### PR TITLE
removed manual poreC install need

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,18 +82,6 @@ conda activate pore_c_snakemake
 
 --- 
 
-#### Installing Pore-C tools
-
-The [Pore-C tools](https://github.com/nanoporetech/pore-c) package required to run this pipeline. They are not yet available through conda so we have to create an environment manually.
-
-```
-git clone https://github.com/nanoporetech/pore-c.git
-cd pore-c
-conda env create
-pip install -e .
-```
-***********
-
 
 # 3. Usage
 

--- a/envs/porec.yml
+++ b/envs/porec.yml
@@ -1,0 +1,34 @@
+name: poreC
+channels:
+  - conda-forge
+  - bioconda
+  - r
+  - defaults
+dependencies:
+  - python>=3.6
+  - snakemake
+  - coreutils
+  - pairtools
+  - pairix
+  - tabix
+  - intake
+  - intake-parquet
+  - streamz
+  - pyarrow
+  - ncls
+  - cooler
+  - tqdm
+  - pysam
+  - biopython
+  - click
+  - numpy
+  - pandas
+  - pytest
+  - pip
+  - pylama
+  - pylint
+  - black
+  - sphinx
+  - sphinx-autodoc-typehints
+  - pip:
+    - git+https://github.com/nanoporetech/pore-c.git

--- a/envs/porec.yml
+++ b/envs/porec.yml
@@ -28,6 +28,7 @@ dependencies:
   - pylama
   - pylint
   - black
+  - python-snappy
   - sphinx
   - sphinx-autodoc-typehints
   - pip:

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -1,6 +1,5 @@
 from box import Box
 
-# ACTIVATE_POREC = "set +u; source ~/miniconda3/etc/profile.d/conda.sh ; conda activate ; conda activate poreC; "
 
 def create_path_accessor(prefix: Path) -> Box:
     """Create a Box to provide '.' access to heirarchy of paths"""

--- a/rules/common.smk
+++ b/rules/common.smk
@@ -1,6 +1,6 @@
 from box import Box
 
-ACTIVATE_POREC = "set +u; source ~/miniconda3/etc/profile.d/conda.sh ; conda activate ; conda activate poreC; "
+# ACTIVATE_POREC = "set +u; source ~/miniconda3/etc/profile.d/conda.sh ; conda activate ; conda activate poreC; "
 
 def create_path_accessor(prefix: Path) -> Box:
     """Create a Box to provide '.' access to heirarchy of paths"""

--- a/rules/exports.smk
+++ b/rules/exports.smk
@@ -5,8 +5,9 @@ rule to_salsa_bed:
     log: to_log(paths.assembly.salsa_bed)
     benchmark: to_benchmark(paths.assembly.salsa_bed)
     threads: config['software']['pore_c']['to_salsa_bed']['threads']
+    conda: "../envs/porec.yml"
     shell:
-        "{ACTIVATE_POREC} pore_c alignments to-salsa-bed {input} {output} -n {threads}"
+        "pore_c alignments to-salsa-bed {input} {output} -n {threads}"
 
 
 rule create_hicRef:
@@ -14,8 +15,9 @@ rule create_hicRef:
     input: paths.virtual_digest.catalog
     log: to_log(paths.juicebox.hicref)
     benchmark: to_log(paths.juicebox.hicref)
+    conda: "../envs/porec.yml"
     shell:
-        "{ACTIVATE_POREC} pore_c refgenome to-hicref {input} {output} 2>{log}"
+        "pore_c refgenome to-hicref {input} {output} 2>{log}"
 
 rule create_hic_txt:
     output: paths.juicebox.hic_txt
@@ -23,5 +25,6 @@ rule create_hic_txt:
         hicref=paths.juicebox.hicref, # dummy dependency, file needed for conversion to binary
         align_catalog=paths.align_table.catalog
     log: to_log(paths.juicebox.hic_txt)
+    conda: "../envs/porec.yml"
     shell:
-       "{ACTIVATE_POREC} pore_c alignments to-hic-txt {input.align_catalog} {output} 2>{log}"
+       "pore_c alignments to-hic-txt {input.align_catalog} {output} 2>{log}"

--- a/rules/mapping.smk
+++ b/rules/mapping.smk
@@ -33,5 +33,6 @@ rule create_alignment_table:
     log: to_log(paths.align_table.catalog)
     benchmark: to_benchmark(paths.align_table.catalog)
     threads: config['software']['pore_c']['create_alignment_table']['threads']
+    conda: "../envs/porec.yml"
     shell:
-        "{ACTIVATE_POREC} pore_c alignments parse {input.bam} {input.virtual_digest} {params.prefix} -n {threads} 2>{log}"
+        "pore_c alignments parse {input.bam} {input.virtual_digest} {params.prefix} -n {threads} 2>{log}"

--- a/rules/matrices.smk
+++ b/rules/matrices.smk
@@ -10,8 +10,9 @@ rule create_base_matrix:
     benchmark: to_benchmark(paths.matrix.catalog)
     log: to_log(paths.matrix.catalog)
     threads: 1
+    conda: "../envs/porec.yml"
     shell:
-        "{ACTIVATE_POREC} pore_c pairs to-matrix {input} {params.prefix} -r {params.resolution} -n {threads} 2>{log}"
+        "pore_c pairs to-matrix {input} {params.prefix} -r {params.resolution} -n {threads} 2>{log}"
 
 
 rule create_base_cooler_file:

--- a/rules/pairs.smk
+++ b/rules/pairs.smk
@@ -9,5 +9,6 @@ rule create_pairs_file:
     benchmark: to_benchmark(paths.pairs.catalog)
     log: to_log(paths.pairs.catalog)
     threads: config['software']['pore_c']['create_pairs_file']['threads']
+    conda: "../envs/porec.yml"
     shell:
-        "{ACTIVATE_POREC} pore_c pairs from-alignment-table {input} {params.prefix} -n {threads} 2>{log}"
+        "pore_c pairs from-alignment-table {input} {params.prefix} -n {threads} 2>{log}"

--- a/rules/reads.smk
+++ b/rules/reads.smk
@@ -9,5 +9,6 @@ rule import_basecalls:
         prefix = to_prefix(paths.basecall.catalog)
     log: to_log(paths.basecall.catalog)
     benchmark: to_benchmark(paths.basecall.catalog)
+    conda: "../envs/porec.yml"
     shell:
-        "{ACTIVATE_POREC} pore_c reads catalog  {params.fname} {params.prefix} 2> {log}"
+        "pore_c reads catalog  {params.fname} {params.prefix} 2> {log}"

--- a/rules/refgenome.smk
+++ b/rules/refgenome.smk
@@ -11,8 +11,9 @@ rule add_refgenome:
         genome_id=config['refgenome']['refgenome_id']
     log: to_log(paths.refgenome.catalog)
     benchmark: to_benchmark(paths.refgenome.catalog)
+    conda: "../envs/porec.yml"
     shell:
-        "{ACTIVATE_POREC} pore_c refgenome catalog {input} {params.prefix} --genome-id {params.genome_id} 2> {log}"
+        "pore_c refgenome catalog {input} {params.prefix} --genome-id {params.genome_id} 2> {log}"
 
 rule virtual_digest:
     input:
@@ -26,8 +27,9 @@ rule virtual_digest:
     benchmark: to_benchmark(paths.virtual_digest.catalog)
     log: to_log(paths.virtual_digest.catalog)
     threads: 10
+    conda: "../envs/porec.yml"
     shell:
-        "{ACTIVATE_POREC} pore_c refgenome virtual-digest {input} enzyme:{wildcards.enzyme} {params.prefix} -n {threads} 2> {log}"
+        "pore_c refgenome virtual-digest {input} enzyme:{wildcards.enzyme} {params.prefix} -n {threads} 2> {log}"
 
 rule bwa_index_refgenome:
     input:


### PR DESCRIPTION
Basically the title. Even though poreC isn't available from conda yet, it can be easily installed by conda using a pip directive. Once, poreC is available via conda, you can vastly simplify the "envs/porec.yml" definition.

This update vastly simplifies installing and running the workflow.

I was able to complete the test run of the workflow using the files in ".test" without issue. 