### PR TITLE
fix a problem with aws-sdk-cpp by downgrading the package

### DIFF
--- a/envs/pore_c.yml
+++ b/envs/pore_c.yml
@@ -5,4 +5,5 @@ channels:
 dependencies:
 - pore-c==0.4.0
 - python==3.8
+- aws-sdk-cpp=1.8.186=h9ad65fb_2
 


### PR DESCRIPTION
Downgrading the `aws-sdk-cpp` in `pore-c.yml` environment to resolve the issue discussed in [here](https://github.com/nanoporetech/Pore-C-Snakemake/issues/30).